### PR TITLE
fix: use chrome.storage for saved queries

### DIFF
--- a/shells/chrome/manifest.edn
+++ b/shells/chrome/manifest.edn
@@ -15,7 +15,7 @@
                             {:chrome/options {:persistent false}
                              :entries        [datalog-console.chrome.extension.background.main]}}
 
- :permissions             ["file:///*" "http://*/*" "https://*/*"]
+ :permissions             ["file:///*" "http://*/*" "https://*/*" "storage"]
  :externally-connectable  {:ids ["*"]}
  :content-security-policy ["default-src 'self';"
                            "script-src 'self' 'unsafe-eval' http://localhost:9610;"

--- a/shells/chrome/manifest.edn
+++ b/shells/chrome/manifest.edn
@@ -1,6 +1,6 @@
 {:manifest_version        2
  :name                    "Datalog Console"
- :version                 "0.2.1"
+ :version                 "0.2.2"
  :description             "Datalog DB administration panel for the chrome console"
  :icons                   {"16"  "images/default/icon-16.png"
                            "32"  "images/default/icon-32.png"

--- a/src/main/datalog_console/components/query.cljs
+++ b/src/main/datalog_console/components/query.cljs
@@ -30,11 +30,11 @@
 
 (defn query []
   (let [saved-query (r/atom ::loading)
-        _ (chromestorage/get-item ::query-text (fn [result] (reset! saved-query (goog.object/get result (str ::query-text)))))
         query-text (r/atom nil)
         query-result (r/atom nil)
         query-error (r/atom nil)]
     @(r/track #(reset! query-text (or @saved-query (get example-queries "All attributes"))))
+    (chromestorage/get-item ::query-text (fn [result] (reset! saved-query (goog.object/get result (str ::query-text)))))
     (fn [conn]
       (if (= ::loading @saved-query)
         [:div "Loading..."]

--- a/src/main/datalog_console/components/query.cljs
+++ b/src/main/datalog_console/components/query.cljs
@@ -3,7 +3,7 @@
             [reagent.core :as r]
             [cljs.reader]
             [cljs.pprint]
-            [datalog-console.lib.localstorage :as localstorage]))
+            [datalog-console.lib.chromestorage :as chromestorage]))
 
 (def example-queries
   {"All attributes" "[:find [?attr ...] \n :where [_ ?attr]]"
@@ -29,43 +29,49 @@
                                                    2 (reverse (sort result)))))]]])))
 
 (defn query []
-  (let [saved-query (localstorage/get-item (str ::query-text))
-        query-text (r/atom (or saved-query (get example-queries "All attributes")))
+  (let [saved-query (r/atom ::loading)
+        _ (chromestorage/get-item ::query-text (fn [result] (reset! saved-query (goog.object/get result (str ::query-text)))))
+        query-text (r/atom nil)
         query-result (r/atom nil)
         query-error (r/atom nil)]
+    @(r/track #(reset! query-text (or @saved-query (get example-queries "All attributes"))))
     (fn [conn]
-      [:div {:class "px-1"}
-       [:p {:class "font-bold"} "Query Editor"]
-       [:div {:class "flex justify-between mb-2 items-baseline"
-              :style {:min-width "20rem"}}
-        [:div {:class "-ml-1"}
-         (for [[k v] example-queries]
-           ^{:key (str k)}
-           [:button {:class "ml-1 mt-1 py-1 px-2 rounded bg-gray-200 border"
-                     :on-click #(reset! query-text v)} k])]]
-       [:form {:on-submit (fn [e]
-                            (.preventDefault e)
-                            (try
-                              (reset! query-result (d/q (cljs.reader/read-string @query-text) @conn))
-                              (reset! query-error nil)
-                              (catch js/Error e
-                                (reset! query-result nil)
-                                (reset! query-error (goog.object/get e "message")))))}
-        [:div {:class "flex flex-col"}
-         [:textarea
-          {:style {:min-width "20rem"}
-           :class        "border p-2"
-           :rows          5
-           :value        @query-text
-           :on-change    (fn [e]
-                           (reset! query-text (goog.object/getValueByKeys e #js ["target" "value"]))
-                           (localstorage/set-item! (str ::query-text) @query-text))}]
-         [:button {:type "submit"
-                   :class "py-1 px-2 rounded-b bg-gray-200 border"}
-          "Run query"]]]
-       [:div {:style {:min-width "20rem"}}
-        (when @query-error
-          [:div {:class "bg-red-200 p-4 rounded"}
-           [:p @query-error]])
-        (when @query-result 
-          [result @query-result])]])))
+      (if (= ::loading @saved-query)
+        [:div "Loading..."]
+        [:div {:class "px-1"}
+         [:p {:class "font-bold"} "Query Editor"]
+         [:div {:class "flex justify-between mb-2 items-baseline"
+                :style {:min-width "20rem"}}
+          [:div {:class "-ml-1"}
+           (for [[k v] example-queries]
+             ^{:key (str k)}
+             [:button {:class "ml-1 mt-1 py-1 px-2 rounded bg-gray-200 border"
+                       :on-click (fn [] 
+                                   (reset! query-text v)
+                                   (chromestorage/set-item! ::query-text v))} k])]]
+         [:form {:on-submit (fn [e]
+                              (.preventDefault e)
+                              (try
+                                (reset! query-result (d/q (cljs.reader/read-string @query-text) @conn))
+                                (reset! query-error nil)
+                                (catch js/Error e
+                                  (reset! query-result nil)
+                                  (reset! query-error (goog.object/get e "message")))))}
+          [:div {:class "flex flex-col"}
+           [:textarea
+            {:style {:min-width "20rem"}
+             :class        "border p-2"
+             :rows          5
+             :value        @query-text
+             :on-change    (fn [e]
+                             (reset! query-text (goog.object/getValueByKeys e #js ["target" "value"]))
+                             (chromestorage/set-item! ::query-text @query-text))}]
+           [:button {:type "submit"
+                     :class "py-1 px-2 rounded-b bg-gray-200 border"}
+            "Run query"]]]
+         [:div {:style {:min-width "20rem"}}
+          (when @query-error
+            [:div {:class "bg-red-200 p-4 rounded"}
+             [:p @query-error]])
+          (when @query-result
+            [result @query-result])]]))))

--- a/src/main/datalog_console/lib/chromestorage.cljs
+++ b/src/main/datalog_console/lib/chromestorage.cljs
@@ -1,0 +1,12 @@
+(ns datalog-console.lib.chromestorage
+  (:require [goog.object :as gobj]))
+
+(defn set-item!
+  "Set `key` in browser's extension storage to `val`. Call optional function `f` when done."
+  [k v]
+  (js/chrome.storage.local.set (clj->js {(str k) v}) nil))
+
+(defn get-item
+  "Returns value of `key` from browser's extension storage. Call optional function `f` when done."
+  [key cb]
+  (js/chrome.storage.local.get (str key) cb))


### PR DESCRIPTION
Fixes an error caused from saving queries to localStorage when a user has third party cookies blocked.